### PR TITLE
fix user profile updates

### DIFF
--- a/lmn/models.py
+++ b/lmn/models.py
@@ -81,7 +81,7 @@ class Note(models.Model):
         return 'Note for user ID {} for show ID {} with title {} text {} posted on {}'.format(self.user, self.show, self.title, self.text, self.posted_date)
 
 class UserProfile(models.Model):
-    user = models.ForeignKey('auth.User', blank=False, on_delete=models.CASCADE)
+    user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
     fav_artist = models.CharField(max_length=100, blank=False)
     fav_venue = models.CharField(max_length=100, blank=False)
 

--- a/lmn/templates/lmn/users/user_profile.html
+++ b/lmn/templates/lmn/users/user_profile.html
@@ -16,7 +16,7 @@ Text truncated to 200 characters. -->
 <div class="row">
   <div class="col" style="text-align: center;">
     
-    <p class="user_email">Email: {{ UserProfile.email }}</p>
+    <p class="user_email">Email: {{ UserProfile.user.email }}</p>
     <p class="user_fav_artist">Favorite Artist: {{ UserProfile.fav_artist }}</p>
     <p class="user_fav_venue">Favorite Venue: {{ UserProfile.fav_venue }}</p>
       

--- a/lmn/views_users.py
+++ b/lmn/views_users.py
@@ -14,7 +14,8 @@ from django.utils import timezone
 def user_profile(request, user_pk):
     user = User.objects.get(pk=user_pk)
     usernotes = Note.objects.filter(user=user.pk).order_by('posted_date').reverse()
-    return render(request, 'lmn/users/user_profile.html', {'user' : user , 'notes' : usernotes })
+    profile = UserProfile.objects.get(user=user_pk)
+    return render(request, 'lmn/users/user_profile.html', {'user' : user , 'notes' : usernotes, 'UserProfile': profile })
 
 
 
@@ -22,24 +23,23 @@ def user_profile(request, user_pk):
 def my_user_profile(request, user_pk):
 
     #user_key = get_object_or_404(UserProfile, pk=user_pk)
-
+    profile = UserProfile.objects.get(user=user_pk)
+        
     if request.method == 'POST':
 
-        form = ProfileEditForm(request.POST)
+        form = ProfileEditForm(request.POST, instance=profile)
         
         if form.is_valid():
             profile = form.save(commit=False)
-            #profile.user = request.user
-            profile = request.user
             profile.save()
             return redirect('lmn:user_profile', user_pk=request.user.pk)
         else:
             form = ProfileEditForm()
-            return render(request, 'lmn/users/my_user_profile.html', { 'form' : form })
+            return render(request, 'lmn/users/my_user_profile.html', { 'form': form })
 
     else:
-        form = ProfileEditForm()
-        return render(request, 'lmn/users/my_user_profile.html', { 'form' : form })
+        form = ProfileEditForm(instance=profile)
+        return render(request, 'lmn/users/my_user_profile.html', { 'form': form })
 
 
 


### PR DESCRIPTION
Fixes to the model - one-to-one field to prevent multiple user profiles associated with one user.  When you create the form to update profile, give it the userprofile to update. One small tweak to the template. 